### PR TITLE
Add support for Juniper and Huawei devices and example commands for Huawei.

### DIFF
--- a/hyperglass/command/construct.py
+++ b/hyperglass/command/construct.py
@@ -113,6 +113,8 @@ class Construct:
         query = None
         ip_version = IPNetwork(target).ip.version
         afi = f"ipv{ip_version}"
+        if self.d_type == "huawei":
+            target = target.replace("/", " ")
         if transport == "rest":
             query = json.dumps({"query_type": query_type, "afi": afi, "target": target})
         if transport == "scrape":

--- a/hyperglass/command/construct.py
+++ b/hyperglass/command/construct.py
@@ -145,6 +145,8 @@ class Construct:
         logger.debug(f"Constructing {query_type} query for {target} via {transport}...")
         afi = "dual"
         query = None
+        if self.d_type == "juniper":
+            target = target.replace("_", ".*")
         if transport == "rest":
             query = json.dumps({"query_type": query_type, "afi": afi, "target": target})
         if transport == "scrape":

--- a/hyperglass/configuration/commands.toml.example
+++ b/hyperglass/configuration/commands.toml.example
@@ -49,3 +49,16 @@ bgp_aspath = "show ip bgp regexp {target}"
 bgp_route = "show ipv6 bgp {target}"
 bgp_community = "show ipv6 bgp community {target}"
 bgp_aspath = "show ipv6 bgp regexp {target}"
+
+[[huawei]]
+[huawei.dual]
+bgp_community = "display bgp routing-table community {target}"
+bgp_aspath = "display bgp routing-table regular-expression {target}"
+[huawei.ipv4]
+bgp_route = "display bgp routing-table {target} longer-prefixes"
+ping = "ping -c 5 -a {source} {target}"
+traceroute = "tracert -a {source} {target}"
+[huawei.ipv6]
+bgp_route = "display bgp ipv6 routing-table {target} longer-prefixes"
+ping = "ping ipv6 -c 5 -a {source} {target}"
+traceroute = "tracert ipv6 -a {source} {target}"


### PR DESCRIPTION
If we use "display bgp routing-table <ip> <mask>" command at Huawei devices, we need use "space", not a "/".
And for Juniper devices when we use as-path regexp, we can't use "_".
And added example commands

https://www.juniper.net/documentation/en_US/junos/topics/usage-guidelines/policy-configuring-as-path-regular-expressions-to-use-as-routing-policy-match-conditions.html#id-10240761
