### PR TITLE
Insufficient timeout when calling FRR or BIRD over REST API for "ping"

### DIFF
--- a/hyperglass/command/execute.py
+++ b/hyperglass/command/execute.py
@@ -74,7 +74,7 @@ class Rest:
             logger.debug(f"FRR endpoint: {frr_endpoint}")
             # End Debug
             frr_response = requests.post(
-                frr_endpoint, headers=headers, data=json_query, timeout=7
+                frr_endpoint, headers=headers, data=json_query, timeout=15
             )
             response = frr_response.text
             status = frr_response.status_code
@@ -111,7 +111,7 @@ class Rest:
             logger.debug(f"BIRD endpoint: {bird_endpoint}")
             # End Debug
             bird_response = requests.post(
-                bird_endpoint, headers=headers, data=json_query, timeout=7
+                bird_endpoint, headers=headers, data=json_query, timeout=15
             )
             response = bird_response.text
             status = bird_response.status_code


### PR DESCRIPTION
With ping on FRR and BIRD using by default a count of 5 (-c 5) and no response timeout (-W), the resulting time it takes for a ping to an unavailable host is too short. As a result end-users see the message that "an error has occured" instead of "Unable to reach x.x.x.x.".
Increasing the API call timeout to 15 seconds fixes this.

<-- Thank you for your interest in contributing to hyperglass. The contribution policy requires that a feature request or bug must be opened prior to a pull request being reviewed. Please list the related feature request or bug below: -->

### Fixes:
https://github.com/checktheroads/hyperglass/issues/43