### PR TITLE
fix(execution/execute): assign variables from nos_parsers later on

### DIFF
--- a/hyperglass/execution/execute.py
+++ b/hyperglass/execution/execute.py
@@ -84,32 +84,32 @@ class Connect:
         parsed = ()
         response = None
 
-        nos_to_parse = nos_parsers.keys()
-        query_type_to_parse = nos_parsers[self.device.nos].keys()
-
         if not self.device.structured_output:
             for coro in parsers:
                 for response in output:
                     _output = await coro(commands=self.query, output=response)
                     parsed += (_output,)
             response = "\n\n".join(parsed)
-        elif (
-            self.device.structured_output
-            and self.device.nos in nos_to_parse
-            and self.query_type not in query_type_to_parse
-        ):
-            for coro in parsers:
-                for response in output:
-                    _output = await coro(commands=self.query, output=response)
-                    parsed += (_output,)
-            response = "\n\n".join(parsed)
-        elif (
-            self.device.structured_output
-            and self.device.nos in nos_to_parse
-            and self.query_type in query_type_to_parse
-        ):
-            func = nos_parsers[self.device.nos][self.query_type]
-            response = func(output)
+        else:
+            nos_to_parse = nos_parsers.keys()
+            query_type_to_parse = nos_parsers[self.device.nos].keys()
+            if (
+                self.device.structured_output
+                and self.device.nos in nos_to_parse
+                and self.query_type not in query_type_to_parse
+            ):
+                for coro in parsers:
+                    for response in output:
+                        _output = await coro(commands=self.query, output=response)
+                        parsed += (_output,)
+                response = "\n\n".join(parsed)
+            elif (
+                self.device.structured_output
+                and self.device.nos in nos_to_parse
+                and self.query_type in query_type_to_parse
+            ):
+                func = nos_parsers[self.device.nos][self.query_type]
+                response = func(output)
 
         if response is None:
             response = "\n\n".join(output)


### PR DESCRIPTION
Without this change, if you had a nos that doesn't have a parser (like "bird"), Python will raise a KeyError.

# Description
After commit b68617495274431b3061f99eba4ed74f88ee486e, if you run a non-parsable nos (aka anything not `juniper`), the server will error:

```
INFO:     172.16.1.8:36078 - "POST /api/query/ HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/uvicorn/protocols/http/httptools_impl.py", line 386, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/usr/local/lib/python3.6/dist-packages/uvicorn/middleware/proxy_headers.py", line 45, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.6/dist-packages/uvicorn/middleware/debug.py", line 81, in __call__
    raise exc from None
  File "/usr/local/lib/python3.6/dist-packages/uvicorn/middleware/debug.py", line 78, in __call__
    await self.app(scope, receive, inner_send)
  File "/usr/local/lib/python3.6/dist-packages/fastapi/applications.py", line 183, in __call__
    await super().__call__(scope, receive, send)  # pragma: no cover
  File "/usr/local/lib/python3.6/dist-packages/starlette/applications.py", line 102, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.6/dist-packages/starlette/middleware/errors.py", line 181, in __call__
    raise exc from None
  File "/usr/local/lib/python3.6/dist-packages/starlette/middleware/errors.py", line 159, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.6/dist-packages/starlette/middleware/cors.py", line 86, in __call__
    await self.simple_response(scope, receive, send, request_headers=headers)
  File "/usr/local/lib/python3.6/dist-packages/starlette/middleware/cors.py", line 142, in simple_response
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.6/dist-packages/starlette/exceptions.py", line 82, in __call__
    raise exc from None
  File "/usr/local/lib/python3.6/dist-packages/starlette/exceptions.py", line 71, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.6/dist-packages/starlette/routing.py", line 550, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.6/dist-packages/starlette/routing.py", line 227, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.6/dist-packages/starlette/routing.py", line 41, in app
    response = await func(request)
  File "/usr/local/lib/python3.6/dist-packages/fastapi/routing.py", line 197, in app
    dependant=dependant, values=values, is_coroutine=is_coroutine
  File "/usr/local/lib/python3.6/dist-packages/fastapi/routing.py", line 147, in run_endpoint_function
    return await dependant.call(**values)
  File "/usr/local/lib/python3.6/dist-packages/hyperglass/api/routes.py", line 121, in query
    cache_output = await Execute(query_data).response()
  File "/usr/local/lib/python3.6/dist-packages/hyperglass/execution/execute.py", line 448, in response
    output = await connect.rest()
  File "/usr/local/lib/python3.6/dist-packages/hyperglass/execution/execute.py", line 412, in rest
    return await self.parsed_response(responses)
  File "/usr/local/lib/python3.6/dist-packages/hyperglass/execution/execute.py", line 89, in parsed_response
    query_type_to_parse = nos_parsers[self.device.nos].keys()
KeyError: 'bird'
```

Well its obvious that `"bird"` is not a dict. So the code execution order is wrong.

# Related Issues
None, internal issue I've had tested and fixed.

# Motivation and Context
This change will fix erroring output if a nos is not supported on `nos_parsers`. Thus, it is required.

# Tests

## hyperglass Host

| Metric | Value |
| ------ | ----- |
| **hyperglass Version** | **1.0.0-beta.52** |
| **hyperglass Path** | `/etc/hyperglass` |
| **Python Version** | `3.6.9` |
| **Platform Info** | `Linux-4.15.0-99-generic-x86_64-with-Ubuntu-18.04-bionic` |
| **CPU Info** | AMD EPYC Processor (with IBPB) |
| **Logical Cores** | `2` |
| **Physical Cores** | `2` |
| **Processor Speed** | 2.4953119999999998GHz |
| **Total Memory** | 2.04 GB |
| **Memory Utilization** | 28.8% |
| **Total Disk Space** | 40.26 GB |
| **Disk Utilization** | 25.9% |

## Route Server
 - OS: Ubuntu 18.04.4 LTS: Kernel `4.15.0-106-generic`
 - Python Version: 3.6.9
 - hyperglass-agent Version: 0.1.0
 - BIRD Version: 2.0.7

## Other tests
**None, requires multiple router platforms to test further**