### PR TITLE
Installation: Clarify Python 3 on CentOS

### DIFF
--- a/docs/docs/agent/installation.mdx
+++ b/docs/docs/agent/installation.mdx
@@ -44,6 +44,14 @@ $ sudo apt install -y python3 python3-pip libssl-dev
 
 <TabItem value="rhel">
 
+You can install python from the CentOS 7 repository:
+
+```shell-session
+$ sudo yum install python3-devel python3-pip
+```
+
+But you can also use the [SCL repository](https://www.softwarecollections.org/en/scls/rhscl/rh-python36/)
+
 ```shell-session
 $ sudo yum install centos-release-scl
 $ sudo yum install rh-python36

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -53,9 +53,17 @@ $ sudo apt install -y python3.6-dev python3-pip redis-server
 
 <TabItem value="rhel">
 
+You can install python from the CentOS 7 repository:
+
 ```shell-session
-$ sudo yum install epel-release centos-release-scl scl-utils python3-devel rh-python36
-$ sudo scl enable rh-python36
+$ sudo yum install python3-devel python3-pip
+```
+
+But you can also use the [SCL repository](https://www.softwarecollections.org/en/scls/rhscl/rh-python36/)
+
+```shell-session
+$ sudo yum install centos-release-scl
+$ sudo yum install rh-python36
 ```
 
 </TabItem>


### PR DESCRIPTION
CentOS 7 has Python 3.6 in the official repositories since some time.
This allows us to get an almost modern Python interpreter onto the
system without fiddling with PATH environment varible like SCL does.

<!-- PLEASE CONSULT CONTRIBUTING.MD PRIOR TO WORKING ON HYPERGLASS -->

<!-- Provide a general summary of your changes in the Title. -->

# Description

This PR just updates the installation instructions for CentOS. Since they have now Python 3.6 in the base repo, we can simply rely on that instead of adding another repo. While I'm not against more repos, SCL in particular can get a bit tricky because of their setup.

# Related Issues
<!-- Link to any related open issues -->

# Motivation and Context

Make SCL optional

# Tests

Since this is just a docs change, I didn't touch any tests. Of course I tried this locally an can confirm that the base repo ships python3.6 and that hyperglass works with that.
