### PR TITLE
Update Juniper model, to only return best match for prefix

### DIFF
--- a/hyperglass/models/commands/juniper.py
+++ b/hyperglass/models/commands/juniper.py
@@ -10,7 +10,7 @@ from .common import CommandSet, CommandGroup
 class _IPv4(CommandSet):
     """Validation model for non-default dual afi commands."""
 
-    bgp_route: StrictStr = 'show route protocol bgp table inet.0 {target} detail | except Label | except Label | except "Next hop type" | except Task | except Address | except "Session Id" | except State | except "Next-hop reference" | except destinations | except "Announcement bits"'
+    bgp_route: StrictStr = 'show route protocol bgp table inet.0 {target} best detail | except Label | except Label | except "Next hop type" | except Task | except Address | except "Session Id" | except State | except "Next-hop reference" | except destinations | except "Announcement bits"'
     bgp_aspath: StrictStr = 'show route protocol bgp table inet.0 aspath-regex "{target}"'
     bgp_community: StrictStr = "show route protocol bgp table inet.0 community {target}"
     ping: StrictStr = "ping inet {target} count 5 source {source}"
@@ -20,7 +20,7 @@ class _IPv4(CommandSet):
 class _IPv6(CommandSet):
     """Validation model for non-default ipv4 commands."""
 
-    bgp_route: StrictStr = 'show route protocol bgp table inet6.0 {target} detail | except Label | except Label | except "Next hop type" | except Task | except Address | except "Session Id" | except State | except "Next-hop reference" | except destinations | except "Announcement bits"'
+    bgp_route: StrictStr = 'show route protocol bgp table inet6.0 {target} best detail | except Label | except Label | except "Next hop type" | except Task | except Address | except "Session Id" | except State | except "Next-hop reference" | except destinations | except "Announcement bits"'
     bgp_aspath: StrictStr = 'show route protocol bgp table inet6.0 aspath-regex "{target}"'
     bgp_community: StrictStr = "show route protocol bgp table inet6.0 community {target}"
     ping: StrictStr = "ping inet6 {target} count 5 source {source}"
@@ -30,7 +30,7 @@ class _IPv6(CommandSet):
 class _VPNIPv4(CommandSet):
     """Validation model for non-default ipv6 commands."""
 
-    bgp_route: StrictStr = 'show route protocol bgp table {vrf}.inet.0 {target} detail | except Label | except Label | except "Next hop type" | except Task | except Address | except "Session Id" | except State | except "Next-hop reference" | except destinations | except "Announcement bits"'
+    bgp_route: StrictStr = 'show route protocol bgp table {vrf}.inet.0 {target} best detail | except Label | except Label | except "Next hop type" | except Task | except Address | except "Session Id" | except State | except "Next-hop reference" | except destinations | except "Announcement bits"'
     bgp_aspath: StrictStr = 'show route protocol bgp table {vrf}.inet.0 aspath-regex "{target}"'
     bgp_community: StrictStr = "show route protocol bgp table {vrf}.inet.0 community {target}"
     ping: StrictStr = "ping inet routing-instance {vrf} {target} count 5 source {source}"
@@ -40,7 +40,7 @@ class _VPNIPv4(CommandSet):
 class _VPNIPv6(CommandSet):
     """Validation model for non-default ipv6 commands."""
 
-    bgp_route: StrictStr = 'show route protocol bgp table {vrf}.inet6.0 {target} detail | except Label | except Label | except "Next hop type" | except Task | except Address | except "Session Id" | except State | except "Next-hop reference" | except destinations | except "Announcement bits"'
+    bgp_route: StrictStr = 'show route protocol bgp table {vrf}.inet6.0 {target} best detail | except Label | except Label | except "Next hop type" | except Task | except Address | except "Session Id" | except State | except "Next-hop reference" | except destinations | except "Announcement bits"'
     bgp_aspath: StrictStr = 'show route protocol bgp table {vrf}.inet6.0 aspath-regex "{target}"'
     bgp_community: StrictStr = "show route protocol bgp table {vrf}.inet6.0 community {target}"
     ping: StrictStr = "ping inet6 routing-instance {vrf} {target} count 5 source {source}"
@@ -49,28 +49,28 @@ class _VPNIPv6(CommandSet):
 
 _structured = CommandGroup(
     ipv4_default=CommandSet(
-        bgp_route="show route protocol bgp table inet.0 {target} detail | display xml",
+        bgp_route="show route protocol bgp table inet.0 {target} best detail | display xml",
         bgp_aspath='show route protocol bgp table inet.0 aspath-regex "{target}" detail | display xml',
         bgp_community="show route protocol bgp table inet.0 community {target} detail | display xml",
         ping="ping inet {target} count 5 source {source}",
         traceroute="traceroute inet {target} wait 1 source {source}",
     ),
     ipv6_default=CommandSet(
-        bgp_route="show route protocol bgp table inet6.0 {target} detail | display xml",
+        bgp_route="show route protocol bgp table inet6.0 {target} best detail | display xml",
         bgp_aspath='show route protocol bgp table inet6.0 aspath-regex "{target}" detail | display xml',
         bgp_community="show route protocol bgp table inet6.0 community {target} detail | display xml",
         ping="ping inet6 {target} count 5 source {source}",
         traceroute="traceroute inet6 {target} wait 2 source {source}",
     ),
     ipv4_vpn=CommandSet(
-        bgp_route="show route protocol bgp table {vrf}.inet.0 {target} detail | display xml",
+        bgp_route="show route protocol bgp table {vrf}.inet.0 {target} best detail | display xml",
         bgp_aspath='show route protocol bgp table {vrf}.inet.0 aspath-regex "{target}" detail | display xml',
         bgp_community="show route protocol bgp table {vrf}.inet.0 community {target} detail | display xml",
         ping="ping inet routing-instance {vrf} {target} count 5 source {source}",
         traceroute="traceroute inet routing-instance {vrf} {target} wait 1 source {source}",
     ),
     ipv6_vpn=CommandSet(
-        bgp_route="show route protocol bgp table {vrf}.inet6.0 {target} detail | display xml",
+        bgp_route="show route protocol bgp table {vrf}.inet6.0 {target} best detail | display xml",
         bgp_aspath='show route protocol bgp table {vrf}.inet6.0 aspath-regex "{target}" detail | display xml',
         bgp_community="show route protocol bgp table {vrf}.inet6.0 community {target} detail | display xml",
         ping="ping inet6 routing-instance {vrf} {target} count 5 source {source}",


### PR DESCRIPTION
Filter route lookup, to only show the best match for prefix.

# Description

Filter route lookup, to only show the best match for prefix. Currently a user could search for 1.0.0.0/8, which would return a lot of results. I propose to only return results for prefix that best matches the query.
