### PR TITLE
Adjust docs to state IPv6 addresses need to be in quotes

### DIFF
--- a/docs/docs/adding-devices.mdx
+++ b/docs/docs/adding-devices.mdx
@@ -131,11 +131,11 @@ May be set to `null` to disable IPv4 for this VRF, on the parent device.
 
 May be set to `null` to disable IPv6 for this VRF, on the parent device.
 
-| Parameter             | Type    | Default | Description                                                                                                      |
-| :-------------------- | :------ | :------ | :--------------------------------------------------------------------------------------------------------------- |
-| <R/> `source_address` | String  |         | Device's source IPv6 address for directed queries (ping, traceroute). This address must be surrounded by quotes. |
-| `force_cidr`          | Boolean | `true`  | Convert IP host queries to actual advertised containing prefix length                                            |
-| `access_list`         |         |         | [IPv6 Access List Configuration](#access_list)                                                                   |
+| Parameter             | Type    | Default | Description                                                                                                                            |
+| :-------------------- | :------ | :------ | :------------------------------------------------------------------------------------------------------------------------------------- |
+| <R/> `source_address` | String  |         | Device's source IPv6 address for directed queries (ping, traceroute). This address must be surrounded by quotes. Ex. "0000:0000:0000::"|
+| `force_cidr`          | Boolean | `true`  | Convert IP host queries to actual advertised containing prefix length                                                                  |
+| `access_list`         |         |         | [IPv6 Access List Configuration](#access_list)                                                                                         |
 
 :::note
 The `force_cidr` option will ensure that a **BGP Route** query for an IP host (/32 IPv4, /128 IPv6) is converted to its containing prefix. For example, a query for `1.1.1.1` would be converted to a query for `1.1.1.0/24`. This is because not all platforms support a BGP lookup for a host (this is primary a problem with IPv6, but the option applies to both address families).

--- a/docs/docs/adding-devices.mdx
+++ b/docs/docs/adding-devices.mdx
@@ -131,11 +131,11 @@ May be set to `null` to disable IPv4 for this VRF, on the parent device.
 
 May be set to `null` to disable IPv6 for this VRF, on the parent device.
 
-| Parameter             | Type    | Default | Description                                                           |
-| :-------------------- | :------ | :------ | :-------------------------------------------------------------------- |
-| <R/> `source_address` | String  |         | Device's source IPv6 address for directed queries (ping, traceroute). |
-| `force_cidr`          | Boolean | `true`  | Convert IP host queries to actual advertised containing prefix length |
-| `access_list`         |         |         | [IPv6 Access List Configuration](#access_list)                        |
+| Parameter             | Type    | Default | Description                                                                                                      |
+| :-------------------- | :------ | :------ | :--------------------------------------------------------------------------------------------------------------- |
+| <R/> `source_address` | String  |         | Device's source IPv6 address for directed queries (ping, traceroute). This address must be surrounded by quotes. |
+| `force_cidr`          | Boolean | `true`  | Convert IP host queries to actual advertised containing prefix length                                            |
+| `access_list`         |         |         | [IPv6 Access List Configuration](#access_list)                                                                   |
 
 :::note
 The `force_cidr` option will ensure that a **BGP Route** query for an IP host (/32 IPv4, /128 IPv6) is converted to its containing prefix. For example, a query for `1.1.1.1` would be converted to a query for `1.1.1.0/24`. This is because not all platforms support a BGP lookup for a host (this is primary a problem with IPv6, but the option applies to both address families).


### PR DESCRIPTION
<!-- PLEASE CONSULT CONTRIBUTING.MD PRIOR TO WORKING ON HYPERGLASS -->

Adjust docs to state IPv6 addresses need to be in quotes.

# Description

As seen in #130, IPv6 addresses need to be surrounded by quotes.

# Related Issues

#130

# Motivation and Context

This solves user frustration and adjusts the docs accordingly. If this is a bug due to something un-intentionally happening it would actually need to be resolved. However, this may be how the application is supposed to function.

# Tests

See #130 
